### PR TITLE
Fix sort by date for tables

### DIFF
--- a/mb-display_sortable_table.user.js
+++ b/mb-display_sortable_table.user.js
@@ -29,7 +29,24 @@ function comparefct(index) {
         if (index === 0) {
             var d1 = new Date(cell1.textContent.split(' – ')[0]),
                 d2 = new Date(cell2.textContent.split(' – ')[0]);
-            return d2 - d1;
+
+            // If the table contains recordings without dates, parsing dates above fails, standard comparison
+            // (d2 - d1) returns NaN, and the sort operation on table fails. We have to process a missing date
+            // as a special case by explicitly checking if the parsing above succeed.
+            // By default (without this script) MusicBrainz shows first recordings with dates in ascending order,
+            // than recording without dates. The code below ensures compatibility of this script with the default
+            // sort order.
+            var d1_NaN = isNaN(d1.getDate()),
+                d2_NaN = isNaN(d2.getDate());
+            if (d1_NaN && d2_NaN) {
+                return 0;
+            } else if (d1_NaN) {
+                return -1;
+            } else if (d2_NaN) {
+                return 1;
+            } else {
+                return d2 - d1;
+            }
         }
         var href1 = $(cell1).find('a');
         if (href1.length) {


### PR DESCRIPTION
Hello,

The script for sorting tables is great, but the current version fails in some cases, see my message on MusicBrainz forum https://community.metabrainz.org/t/sort-columns/388528/7 for details.

The current version of this script fails to properly sort a table with recordings by date if for some recordings no date is set. Example page: https://musicbrainz.org/work/1cba82ba-a6f3-3590-a0c1-b9e742fa742d.

The error happens because the "new Date()", when used with an empty input string, creates a date with the status "invalid". An attempt to calculate "d2 - d1" return NaN, and the whole sort method fails.

The provided fix explicitly checks if dates were parsed successfully, and provides a special sort logic for invalid dates: an invalid date is greater than any valid date. This is consistent with the default sort logic in MusicBrainz recordings table, which shows first recordings with available dates sorted by date in ascending order, and than all recordings without dates.