### PR TITLE
Replace lodash with native code

### DIFF
--- a/mb-display_acousticbrainz_data_for_recording.user.js
+++ b/mb-display_acousticbrainz_data_for_recording.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: display AcousticBrainz data on recording page
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/recording/*
 // @exclude      http*://*musicbrainz.org/recording/merge
 // @exclude      http*://*musicbrainz.org/recording/*/*

--- a/mb-display_acousticbrainz_data_for_recording.user.js
+++ b/mb-display_acousticbrainz_data_for_recording.user.js
@@ -1,10 +1,10 @@
-/* global _ sidebar helper */
+/* global sidebar helper */
 'use strict';
 // ==UserScript==
 // @name         MusicBrainz: Display AcousticBrainz data on recording page
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2019.9.22
+// @version      2020.9.8
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-display_acousticbrainz_data_for_recording.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-display_acousticbrainz_data_for_recording.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -20,6 +20,11 @@
 // @run-at       document-end
 // ==/UserScript==
 
+const round = (num, precision) => {
+  const modifier = 10 ** precision
+  return Math.round(num * modifier) / modifier
+}
+
 function showAcousticBrainzData() {
     const mbid = helper.mbidFromURL();
     fetch(`//acousticbrainz.org/api/v1/${mbid}/count`).then(
@@ -32,11 +37,11 @@ function showAcousticBrainzData() {
                 resp => resp.json()
             ).then(data => {
                 document.getElementById('ABkey').append(
-                    `${data.tonal.key_key} ${data.tonal.key_scale} (${_.round(
+                    `${data.tonal.key_key} ${data.tonal.key_scale} (${round(
                         100 * data.tonal.key_strength, 1)}%)`
                 );
-                document.getElementById('ABfreq').append(_.round(data.tonal.tuning_frequency, 2));
-                document.getElementById('ABbpm').append(_.round(data.rhythm.bpm, 1));
+                document.getElementById('ABfreq').append(round(data.tonal.tuning_frequency, 2));
+                document.getElementById('ABbpm').append(round(data.rhythm.bpm, 1));
                 document.getElementById('ABbeatcount').append(data.rhythm.beats_count);
             });
         }

--- a/mb-display_acousticbrainz_dataset_for_work.user.js
+++ b/mb-display_acousticbrainz_dataset_for_work.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: display acousticbrainz count on Work page
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*
 // @exclude      http*://*musicbrainz.org/work/*/*
 // @grant        none

--- a/mb-display_count_alias.user.js
+++ b/mb-display_count_alias.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Display alias count on work/artist pages
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=791422
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*
 // @exclude      http*://*musicbrainz.org/work/add*
 // @exclude      http*://*musicbrainz.org/work/create*

--- a/mb-display_count_discid.user.js
+++ b/mb-display_count_discid.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Display discid count on main release pages
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/release/*
 // @exclude      http*://*musicbrainz.org/release/add*
 // @exclude      http*://*musicbrainz.org/release/*/*

--- a/mb-display_sortable_table.user.js
+++ b/mb-display_sortable_table.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Make table columns sortable
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=802926
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*
 // @include      http*://*musicbrainz.org/instrument/*/recordings
 // @include      http*://*musicbrainz.org/instrument/*/recordings?page=*

--- a/mb-display_work_relations_for_artist_recordings.user.js
+++ b/mb-display_work_relations_for_artist_recordings.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Mark recordings not linked to any work on an artist recordings or relationships page
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/artist/*/relationships
 // @include      http*://*musicbrainz.org/artist/*/recordings*
 // @grant        none

--- a/mb-edit-add_aliases.user.js
+++ b/mb-edit-add_aliases.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org edit: Add entity aliases in batch
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241981
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/*/*/aliases*
 // @exclude      http*://*musicbrainz.org/doc/*
 // @grant        none

--- a/mb-edit-create_from_wikidata.user.js
+++ b/mb-edit-create_from_wikidata.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org edit: create entity or fill data from wikipedia / wikidata / VIAF / ISNI
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/artist/create*
 // @include      http*://*musicbrainz.org/artist/*/edit
 // @exclude      http*://*musicbrainz.org/artist/*/alias/*/edit

--- a/mb-edit-create_from_wikidata.user.js
+++ b/mb-edit-create_from_wikidata.user.js
@@ -1,10 +1,10 @@
-/* global $ _ helper relEditor sidebar GM_info GM_xmlhttpRequest */
+/* global $ helper relEditor sidebar GM_info GM_xmlhttpRequest */
 'use strict';
 // ==UserScript==
 // @name         MusicBrainz edit: Create entity or fill data from wikipedia / wikidata / VIAF / ISNI
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2020.8.17
+// @version      2020.9.8
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -295,12 +295,12 @@ const FIELD_NAMES = {
     'area': 'Area',
 };
 
-_.forOwn(FIELD_NAMES, (v, k) => {
-    if (k.includes('artist')) {
-        FIELD_NAMES[k.replace('artist', 'place')] = v;
-        FIELD_NAMES[k.replace('artist', 'work')] = v;
+for (const [key, value] of Object.entries(FIELD_NAMES)) {
+    if (key.includes('artist')) {
+        FIELD_NAMES[key.replace('artist', 'place')] = value;
+        FIELD_NAMES[key.replace('artist', 'work')] = value;
     }
-});
+}
 
 
 function setValue(nodeId, value, callback) {
@@ -540,7 +540,7 @@ function _fillFormFromWikidata(entity, entityType) {
     }
 
     const existingDomains = _existingDomains();
-    _.forOwn(libWD.urls, (url, externalLink) => {
+    for (const [externalLink, url] of Object.entries(libWD.urls)) {
         const domain = url.split('/')[2];
         if (!libWD.existField(entity, externalLink)) {
             return;
@@ -551,7 +551,7 @@ function _fillFormFromWikidata(entity, entityType) {
             (!domain && !existingDomains.includes(url.split('/')[2]))) {
             _fillExternalLinks(url);
         }
-    });
+    }
 
     for (const role of ['student', 'teacher']) {
         if (libWD.existField(entity, role)) {

--- a/mb-edit-create_release_from_recording.user.js
+++ b/mb-edit-create_release_from_recording.user.js
@@ -13,7 +13,7 @@
 // @compatible   firefox+tampermonkey
 // @license      MIT
 // @require      https://greasyfork.org/scripts/20955-mbimport/code/mbimport.js?version=794744
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=802926
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/recording/*
 // @exclude      http*://*musicbrainz.org/recording/merge
 // @exclude      http*://*musicbrainz.org/recording/*/*

--- a/mb-edit-create_work_arrangement.user.js
+++ b/mb-edit-create_work_arrangement.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Create work arrangement from existing work
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=802926
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*
 // @exclude      http*://*musicbrainz.org/work/*/*
 // @grant        none

--- a/mb-edit-edit_subworks.user.js
+++ b/mb-edit-edit_subworks.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org edit: replace subwork titles/attributes in Work edit page
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*/edit
 // @exclude      http*://*musicbrainz.org/work/*/alias/*/edit
 // @grant        none

--- a/mb-edit-merge_from_acoustid.user.js
+++ b/mb-edit-merge_from_acoustid.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: display acoustIDs and merge recordings with common acoustID
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*
 // @include      http*://*musicbrainz.org/artist/*/relationships
 // @include      http*://*musicbrainz.org/artist/*/recordings

--- a/mb-edit-merge_from_acoustid.user.js
+++ b/mb-edit-merge_from_acoustid.user.js
@@ -1,10 +1,10 @@
-/* global $ _ helper requests sidebar */
+/* global $ helper requests sidebar */
 'use strict';
 // ==UserScript==
 // @name         MusicBrainz edit: Display acoustIDs and merge recordings with common acoustID
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2019.9.22
+// @version      2020.9.8
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-merge_from_acoustid.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-merge_from_acoustid.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -72,7 +72,7 @@ function showAcoustids() {
         }
         var duplicate_ids = Object.keys(ids).filter(
             // true if distinct recordings use the same acoustID
-            acid => _.uniq(ids[acid]).length > 1
+            acid => [...new Set(ids[acid])].size > 1
         );
         duplicate_ids.forEach(function (acid) {
             $('#acidForMerge').append(

--- a/mb-edit-set_work_aliases.user.js
+++ b/mb-edit-set_work_aliases.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Set recording names as work aliases
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/work/*/aliases
 // @grant        none
 // @run-at       document-end

--- a/mb-edit-set_work_attributes.user.js
+++ b/mb-edit-set_work_attributes.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org: Set attributes (type, lang, key) from the composer Work page
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/artist/*/works
 // @include      http*://*musicbrainz.org/artist/*/works?page=*
 // @grant        none

--- a/mb-reledit-copy_dates.user.js
+++ b/mb-reledit-copy_dates.user.js
@@ -12,7 +12,7 @@
 // @description  musicbrainz.org relation editor: Copy/remove dates on recording relations
 // @compatible   firefox+tampermonkey
 // @license      MIT
-// @require      https://greasyfork.org/scripts/13747-mbz-loujine-common/code/mbz-loujine-common.js?version=241520
+// @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
 // @include      http*://*musicbrainz.org/release/*/edit-relationships
 // @grant        none
 // @run-at       document-end

--- a/mb-reledit-copy_dates.user.js
+++ b/mb-reledit-copy_dates.user.js
@@ -1,10 +1,10 @@
-/* global $ _ MB server relEditor GM_info */
+/* global $ MB server relEditor GM_info */
 'use strict';
 // ==UserScript==
 // @name         MusicBrainz relation editor: Copy dates on recording relations
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2020.4.12
+// @version      2020.9.8
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-reledit-copy_dates.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-reledit-copy_dates.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -41,7 +41,7 @@ function referenceDate(relations) {
     for (const unit of ['day', 'month', 'year']) {
         for (const [idx, rel] of relations.entries()) {
             if (rel.end_date[unit]() > 0
-                && _.values(server.recordingLinkType).includes(
+                && Object.values(server.recordingLinkType).includes(
                     parseInt(rel.linkTypeID()))) {
                 return idx;
             }
@@ -58,7 +58,7 @@ function propagateDates() {
         if (idx !== -1) {
             relations.forEach(function(rel) {
                 var linkType = parseInt(rel.linkTypeID());
-                if (!rel.removed() && _.values(server.recordingLinkType).includes(linkType)) {
+                if (!rel.removed() && Object.values(server.recordingLinkType).includes(linkType)) {
                     copyDate(relations[idx], rel);
                 }
             });

--- a/mbz-loujine-common.js
+++ b/mbz-loujine-common.js
@@ -1,10 +1,10 @@
-/* global _ MB */
+/* global MB */
 'use strict';
 // ==UserScript==
 // @name         mbz-loujine-common
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2020.5.8
+// @version      2020.9.8
 // @description  musicbrainz.org: common functions
 // @compatible   firefox+greasemonkey
 // @license      MIT
@@ -320,7 +320,7 @@ class Server {
     getRelationshipAttrInfo() {
         const scriptSrc = document.scripts[document.scripts.length - 1].text;
         const jsonSource = new RegExp(/RE.exportTypeInfo\(\n(.*),\n(.*)\n/).exec(scriptSrc);
-        return _.values(JSON.parse(jsonSource[2]));
+        return Object.values(JSON.parse(jsonSource[2]));
     }
 
     getInstrumentRelationshipAttrInfo() {
@@ -343,13 +343,13 @@ const server = new Server();
 function buildOptions(obj) {
     // to be replaced by Object.entries when all supported browser versions
     // recognize it
-    return _.toPairs(obj).map(
+    return Object.entries(obj).map(
         ([type, code]) => `<option value="${code}">${type}</option>`
     ).join('');
 }
 
 function buildLanguageOptions(obj) {
-    return _.toPairs(obj).map(
+    return Object.entries(obj).map(
         ([type, code]) => `<option class="language" value="${code}">${type}</option>`
     ).join('');
 }
@@ -570,7 +570,7 @@ class Edits {
     }
 
     formatEdit(editType, info) {
-        return _.toPairs(info).map(
+        return Object.entries(info).map(
             ([prop, val]) => val === null ? `${editType}.${prop}`
                                           : `${editType}.${prop}=${val}`
         ).join('&');
@@ -629,13 +629,17 @@ class Helper {
         return this._isEntityTypeURL('work')
     }
 
+    sortBy = (key) => {
+    return (a, b) => (a[key] > b[key]) ? 1 : ((b[key] > a[key]) ? -1 : 0);
+    }
+
     sortSubworks(work) {
         let rels = work.relationships;
         rels = rels.filter(rel =>
             (rel.linkTypeID === server.workLinkType.subwork
              && rel.direction !== 'backward')
         );
-        rels = _.sortBy(rels, rel => rel.linkOrder);
+        rels = rels.sort(sortBy('linkOrder'));
         return rels.map(rel => rel.target);
     }
 }


### PR DESCRIPTION
MB has dropped Lodash and this was causing issues. I only tested the Wikidata change directly, since I don't use the others, but I think this should work? Please do test it though :) 

I also changed the scripts to track the latest common file from github master rather than a fixed version in an external website (since without that the scripts would still be broken anyway until the external website gets changed). I can drop that one if you have a specific reason to prefer the existing way though!