### PR TITLE
Ensure filling URLs happens on a URL input element

### DIFF
--- a/mb-edit-create_from_wikidata.user.js
+++ b/mb-edit-create_from_wikidata.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Create entity or fill data from wikipedia / wikidata / VIAF / ISNI
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2021.8.22
+// @version      2021.9.25
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -405,8 +405,7 @@ function _fillExternalLinks(url) {
             valueSetter.call(element, value);
         }
     }
-    const fields = document.getElementById('external-links-editor')
-                           .getElementsByTagName('input');
+    const fields = document.querySelectorAll('#external-links-editor input[type="url"]');
     const input = fields[fields.length - 1];
     _setNativeValue(input, url);
     input.dispatchEvent(new Event('input', {'bubbles': true}));


### PR DESCRIPTION
There's an incompatibility between your "Create entity or fill data from wikipedia / wikidata / VIAF / ISNI" and my "Paste multiple external links at once" causing a crash in your script. When "Create entity or fill data from wikipedia / wikidata / VIAF / ISNI" tries to fill in a URL, it selects the last `input` element in the external links editor, expecting it to be the URL input, but "Paste multiple external links at once" adds a new checkbox input as the last element, which makes things go awry. The incompatibility is much easier to fix on your side than mine. :)

Related:
Second part of https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/25
https://github.com/ROpdebee/mb-userscripts/issues/54