### PR TITLE
Clone release relations: Minor improvements

### DIFF
--- a/mb-reledit-clone_relations.user.js
+++ b/mb-reledit-clone_relations.user.js
@@ -140,7 +140,9 @@ function cloneReleaseExtAR(relMBID) {
     let dialog;
 
     requests.GET(`/ws/js/entity/${relMBID}?inc=rels`, resp => {
-        const sourceRels = JSON.parse(resp).relationships;
+        const sourceRels = JSON.parse(resp).relationships.filter(
+            rel => rel.target_type != 'url'
+        );
         sourceRels.map(sourceRel => {
             dialog = new MB.relationshipEditor.UI.AddDialog({
                 viewModel: vm,

--- a/mb-reledit-clone_relations.user.js
+++ b/mb-reledit-clone_relations.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz relation editor: Clone recording relations onto other recordings
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2021.12.31
+// @version      2022.1.2
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-reledit-clone_relations.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-reledit-clone_relations.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -103,7 +103,6 @@ function cloneExtAR(recMBID) {
                     source: rec,
                     target: sourceRel.target,
                 });
-                dialog.accept();
 
                 dialog.relationship().linkTypeID(sourceRel.linkTypeID);
                 dialog.relationship().setAttributes(sourceRel.attributes);
@@ -124,8 +123,8 @@ function cloneExtAR(recMBID) {
                     dialog.relationship().end_date.year(sourceRel.end_date.year);
                     dialog.relationship().end_date.month(sourceRel.end_date.month);
                     dialog.relationship().end_date.day(sourceRel.end_date.day);
-                    dialog.accept();
                 }
+                dialog.accept();
             });
         });
     });
@@ -149,7 +148,6 @@ function cloneReleaseExtAR(relMBID) {
                 source: release,
                 target: sourceRel.target,
             });
-            dialog.accept();
 
             dialog.relationship().linkTypeID(sourceRel.linkTypeID);
             dialog.relationship().setAttributes(sourceRel.attributes);
@@ -166,8 +164,8 @@ function cloneReleaseExtAR(relMBID) {
                 dialog.relationship().end_date.year(sourceRel.end_date.year);
                 dialog.relationship().end_date.month(sourceRel.end_date.month);
                 dialog.relationship().end_date.day(sourceRel.end_date.day);
-                dialog.accept();
             }
+            dialog.accept();
         });
     });
 }

--- a/mb-reledit-clone_relations.user.js
+++ b/mb-reledit-clone_relations.user.js
@@ -234,7 +234,7 @@ $(document).ready(function () {
             cloneReleaseExtAR(relMBID);
         }
         if (!appliedNote) {
-            relEditor.editNote(GM_info.script);
+            relEditor.editNote(GM_info.script, 'Cloned from https://musicbrainz.org/release/' + relMBID);
             appliedNote = true;
         }
     });


### PR DESCRIPTION
- Skip `release-url` rels:
  They are causing a type error because you can't add URLs in the release relationship editor.
- State the source release in the edit note.
- Remove `dialog.accept()` duplicates:
  Accepting each relationship dialog once at the very end is enough.