### PR TITLE
[wikidata] Dispatch input event to trigger area autocomplete

### DIFF
--- a/mb-edit-create_from_wikidata.user.js
+++ b/mb-edit-create_from_wikidata.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Create entity or fill data from wikipedia / wikidata / VIAF / ISNI
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2023.2.2
+// @version      2023.2.3
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_from_wikidata.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -326,7 +326,7 @@ function setValue(nodeId, value, callback) {
     if (!node.value.trim()) {
         // field was empty
         node.value = value;
-        $(node).trigger('change');
+        node.dispatchEvent(new Event('change'));
         $('#newFields').append(
             $('<dd>',
               {'text': `Added "${printableValue}"`}).css('color', 'green')

--- a/mb-edit-create_from_wikidata.user.js
+++ b/mb-edit-create_from_wikidata.user.js
@@ -196,7 +196,7 @@ class WikiDataHelpers {
         }
         if (this.existField(entityArea, 'mbidArea')) {
             input.value = this.fieldValue(entityArea, 'mbidArea');
-            $(input).trigger('keydown');
+            input.dispatchEvent(new Event('input'));
             $('#area-bubble').remove();
         } else {
             input.value = area;


### PR DESCRIPTION
Fixes #59.

`$(input).trigger('input')` has no effect, although it did work for some input fields of MBS in the past, but that's no longer the case. So I've used vanilla JS instead (as I also did for some of my MB bookmarklets when jQuery events no longer did their job).