### PR TITLE
[video recordings] Adapt script for newer server code (close #58)

### DIFF
--- a/mbz-loujine-common.js
+++ b/mbz-loujine-common.js
@@ -591,7 +591,13 @@ class Edits {
      */
     getEditParams(url, callback) {
         requests.GET(url, resp => {
-            const data = new RegExp(/sourceData: (.*),\n/).exec(resp)[1];
+            let data;
+            if (resp.includes('source_entity')) {
+               data = new RegExp(/source_entity":(.*)},"user":/).exec(resp)[1];
+            } else {
+               // pre PR musicbrainz-server#2582
+               data = new RegExp(/sourceData: (.*),\n/).exec(resp)[1];
+            }
             callback(JSON.parse(data));
         });
     }


### PR DESCRIPTION
The script was parsing the code of the /recording/edit page to find required edit parameters. This code has changed in musicbrainz-server but can still be found in the same html source code in a 'source_type' javascript object
