### PR TITLE
Keep all existing attributes when editing a work (close #53)

### DIFF
--- a/mb-edit-create_work_arrangement.user.js
+++ b/mb-edit-create_work_arrangement.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Create work arrangement from existing work
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2021.9.19
+// @version      2023.2.4
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_work_arrangement.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-create_work_arrangement.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -22,7 +22,7 @@
 
 function createArrangement(mbid, parentMbid) {
     $('#create-arrangement-text').empty();
-    edits.getWorkEditParams(
+    edits.getWorkEditParamsFromJSON(
         helper.wsUrl('work', ['artist-rels', 'work-rels'], mbid),
         editData => {
             // do not copy ISWC to arrangement

--- a/mb-edit-edit_subworks.user.js
+++ b/mb-edit-edit_subworks.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Replace subwork titles and attributes in Work edit page
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2020.11.16
+// @version      2023.2.4
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-edit_subworks.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-edit_subworks.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -36,6 +36,7 @@ function replaceSubworksTitles() {
             return;
         }
         const mbid = helper.mbidFromURL(node.href);
+        const url = edits.urlFromMbid('work', mbid);
 
         function success(xhr) {
             const $status = $('#replace' + _idx);
@@ -64,8 +65,6 @@ function replaceSubworksTitles() {
             ).parent().css('color', 'red');
         }
         function callback(editData) {
-            // no need to POST relations
-            delete editData.relations;
             $('#replace' + _idx).text('Sending edit data');
             editData.name = name;
             $('#replace' + _idx).text(' replaced by ' + name);
@@ -73,7 +72,7 @@ function replaceSubworksTitles() {
             postData.edit_note = sidebar.editNote(GM_info.script);
             console.info('Data ready to be posted: ', postData);
             requests.POST(
-                edits.urlFromMbid('work', mbid),
+                url,
                 edits.formatEdit('edit-work', postData),
                 success,
                 fail
@@ -82,7 +81,7 @@ function replaceSubworksTitles() {
         setTimeout(function () {
             $(node).after('<span id="replace' + _idx + '">' +
                           'Fetching required data</span>');
-            edits.getWorkEditParams(helper.wsUrl('work', [], mbid), callback);
+            edits.getWorkEditParams(url, callback);
         }, 2 * idx * server.timeout);
         idx += 1;
     });

--- a/mb-edit-set_work_attributes.user.js
+++ b/mb-edit-set_work_attributes.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Set work attributes from the composer Work page
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2021.9.19
+// @version      2023.2.4
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-set_work_attributes.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-set_work_attributes.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -86,6 +86,7 @@ function updateFromPage(editData, node) {
 function editWork() {
     $('.commit:input:checked:enabled').each(function (idx, node) {
         const mbid = node.id.replace('edit-', '');
+        const url = edits.urlFromMbid('work', mbid);
         function success(xhr) {
             const $status = $('#' + node.id + '-text');
             node.disabled = true;
@@ -107,14 +108,12 @@ function editWork() {
             ).parent().css('color', 'red');
         }
         function callback(editData) {
-            // no need to POST relations
-            delete editData.relations;
             $('#' + node.id + '-text').text('Sending edit data');
             const postData = edits.prepareEdit(updateFromPage(editData, node));
             postData.edit_note = $('#batch_replace_edit_note')[0].value;
             console.info('Data ready to be posted: ', postData);
             requests.POST(
-                edits.urlFromMbid('work', mbid),
+                url,
                 edits.formatEdit('edit-work', postData),
                 success,
                 fail
@@ -124,7 +123,7 @@ function editWork() {
             $('#' + node.id + '-text').empty();
             $(node).after('<span id="' + node.id + '-text">' +
                           'Fetching required data</span>');
-            edits.getWorkEditParams(helper.wsUrl('work', [], mbid), callback);
+            edits.getWorkEditParams(url, callback);
         }, 2 * idx * server.timeout);
     });
 }


### PR DESCRIPTION
It is easier to get edit parameters from the source code of the /edit/page rather than from the public API and having to reconvert everything to the format expected by the POST request
