### PR TITLE
Stop running when no sidebar change quality link

### DIFF
--- a/mb-edit-change_release_quality.user.js
+++ b/mb-edit-change_release_quality.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz edit: Change release quality
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2023.2.19
+// @version      2023.3.10.2112
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-change_release_quality.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mb-edit-change_release_quality.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -13,10 +13,7 @@
 // @compatible   firefox+tampermonkey
 // @license      MIT
 // @require      https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/mbz-loujine-common.js
-// @include      http*://*musicbrainz.org/release/*
-// @exclude      http*://*musicbrainz.org/release/add
-// @exclude      http*://*musicbrainz.org/release/*/edit
-// @exclude      http*://*musicbrainz.org/release/*/edit-relationships
+// @match        *://*.musicbrainz.org/release/*
 // @grant        none
 // @run-at       document-end
 // ==/UserScript==
@@ -77,17 +74,16 @@ function _changeQuality(offsetQuality) {
     document.getElementById('upgrade_quality').style.cursor = 'pointer';
     document.getElementById('downgrade_quality').style.color = 'red';
     document.getElementById('downgrade_quality').style.cursor = 'pointer';
-})();
-
-$(document).ready(function () {
-    if (!helper.isUserLoggedIn()) {
+    $(document).ready(function () {
+        if (!helper.isUserLoggedIn()) {
+            return false;
+        }
+        document.getElementById('upgrade_quality').addEventListener('click', () => {
+            _changeQuality(1)
+        });
+        document.getElementById('downgrade_quality').addEventListener('click', () => {
+            _changeQuality(-1)
+        });
         return false;
-    }
-    document.getElementById('upgrade_quality').addEventListener('click', () => {
-        _changeQuality(1)
     });
-    document.getElementById('downgrade_quality').addEventListener('click', () => {
-        _changeQuality(-1)
-    });
-    return false;
-});
+})();


### PR DESCRIPTION
Fixes #74: Crashes MBS menu on pages with no sidebar change quality links

And replace unsafe `@include` by `@match`:

- `@match *://` allows only `http://` and `https://`
- `@match` {…} `//*.musicbrainz.org` allows only
  `//musicbrainz.org` and `//subdomains.musicbrainz.org`

No need for `@exclude` as we can forget some, miss future tabs and as we are already stopping the script when change quality link not found.

We could also use the single `// @include      /^https?:\/\/([^.]+\.)?musicbrainz\.org\/release\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\/(discids|cover-art|aliases|tags|details))?$/` but again, listing all working or non-working tabs may cause issues with MBS evolutions and we already test the presence of change quality link.