### PR TITLE
mb-reledit-set_instruments: typeID fix

### DIFF
--- a/mb-reledit-set_instruments.user.js
+++ b/mb-reledit-set_instruments.user.js
@@ -29,7 +29,7 @@ const setInstrument = (fromType, toType, fromAttrId, toAttrId, toCredit) => {
         ).filter(
             rel => (
                 (isNaN(fromAttrId) && rel.attributes.length === 0)
-                || rel.attributes.map(attr => attr.type.id).includes(fromAttrId)
+                || rel.attributes.map(attr => attr.typeID).includes(fromAttrId)
             )
         ).forEach(async (rel, relIdx) => {
             await helper.delay(relIdx * 10);
@@ -64,8 +64,8 @@ const setInstrument = (fromType, toType, fromAttrId, toAttrId, toCredit) => {
             let idx;
             let attrs = rel.attributes;
             if (!isNaN(fromAttrId)) {
-                idx = attrs.findIndex(attr => attr.type.id == fromAttrId);
-                attrs = attrs.filter(attr => attr.type.id != fromAttrId);
+                idx = attrs.findIndex(attr => attr.typeID == fromAttrId);
+                attrs = attrs.filter(attr => attr.typeID != fromAttrId);
             }
             if (toAttr) {
                 // attrs order must be kept for credits, etc.


### PR DESCRIPTION
This script has not quite worked for a while, likely after MB moved a lot of pages to React. Based on a suggestion in the MetaBrainz Discourse community, I swapped names in three places, and that seems to have gotten it working again.