### PR TITLE
feat: fetch info and change buttons for MBID only recordings

### DIFF
--- a/acoustid-merge-recordings.user.js
+++ b/acoustid-merge-recordings.user.js
@@ -4,7 +4,7 @@
 // @name         MusicBrainz: merge recordings from acoustID page
 // @namespace    mbz-loujine
 // @author       loujine
-// @version      2020.9.14
+// @version      2024.12.1
 // @downloadURL  https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/acoustid-merge-recordings.user.js
 // @updateURL    https://raw.githubusercontent.com/loujine/musicbrainz-scripts/master/acoustid-merge-recordings.user.js
 // @supportURL   https://github.com/loujine/musicbrainz-scripts
@@ -20,6 +20,58 @@
 function checkAll() {
     document.querySelectorAll('.mbmerge').forEach(function (node) {
         node.checked = true;
+    });
+}
+
+function checkRecordings(undefined_recordings) {
+    // fetch info and change buttons for MBID only recordings
+    undefined_recordings.forEach((undefined_recording, idx) => {
+        setTimeout(() => {
+            GM_xmlhttpRequest({
+                method: 'GET',
+                url: `https://musicbrainz.org/recording/${undefined_recording.mbid}`,
+                onreadystatechange: resp => {
+                    const mbid = resp.finalUrl.split('/')[4];
+                    var obsolete_elements = '';
+                    if (resp.status == '404') {
+                        if (resp.readyState === 2) {
+                            // recording was deleted
+                            obsolete_elements += '.mbmerge, form, .loading';
+                            undefined_recording.tr.style.setProperty('background-color', '#fee');
+                            undefined_recording.tr.cells[0].insertAdjacentHTML('afterbegin', 'deleted: ');
+                        }
+                    } else if (
+                        mbid != undefined_recording.mbid
+                        && undefined_recording.tr.parentNode.querySelector(`tr[id='${mbid}']`)
+                    ) {
+                        if (resp.readyState === 2) {
+                            // recording was merged into a recording visible in this page
+                            obsolete_elements += '.mbmerge, form, .loading';
+                            Array.from(undefined_recording.tr.cells).forEach(cell => {
+                                cell.style.setProperty('border', 'none');
+                            });
+                            undefined_recording.tr.style.setProperty('opacity', '.6');
+                            undefined_recording.tr.cells[0].insertAdjacentHTML('afterbegin', '&nbsp;&nbsp;└ merged: ');
+                            undefined_recording.tr.parentNode.querySelector(`tr[id='${mbid}']`).insertAdjacentElement(
+                                'afterend',
+                                undefined_recording.tr.parentNode.removeChild(undefined_recording.tr)
+                            );
+                        }
+                    } else {
+                        if (resp.readyState == 4) {
+                            // recording was merged into a recording not visible in this page
+                            obsolete_elements += '.loading';
+                            undefined_recording.tr.querySelector('a[href]').textContent = resp.responseXML.title.replace(/ - MusicBrainz$/, '');
+                        }
+                    }
+                    if (obsolete_elements) {
+                        undefined_recording.tr.querySelectorAll(obsolete_elements).forEach(element => {
+                            element.parentNode.removeChild(element);
+                        });
+                    }
+                },
+            });
+        }, 1000 * idx);
     });
 }
 
@@ -63,19 +115,23 @@ function launchMerge() {
           <input id="checkAll" value="Select all" type="button">
         </th>
     `);
+    var undefined_recordings = [];
     document.querySelectorAll('table a[href*="/recording/"]').forEach(node => {
         const mbid = node.href.split('/')[4];
-        const tr = node.parentElement.parentElement;
-        if (
-            node.parentElement.tagName != 'I' &&
-            !tr.classList.contains('mbid-disabled')
-        ) {
-            tr.insertAdjacentHTML(
-                'beforeend',
-                `<td><input class="mbmerge" value="${mbid}" type="checkbox"></td>`
+        const tr = node.closest('tr');
+        tr.insertAdjacentHTML(
+            'beforeend',
+            `<td><input class="mbmerge" value="${mbid}" type="checkbox"></td>`
+        );
+        if (node.parentElement.tagName == 'I') {
+            undefined_recordings.push({tr: tr, mbid: mbid});
+            tr.cells[0].insertAdjacentHTML(
+                'afterbegin',
+                '<span class="loading"><img src="https://musicbrainz.org/static/images/icons/loading.gif"> </span>'
             );
         }
     });
+    checkRecordings(undefined_recordings);
     document.getElementsByTagName('table')[1].insertAdjacentHTML('afterend', `
         <input id="merge" value="Launch merge in MusicBrainz" type="button">
         <span id="merge-text"></span>


### PR DESCRIPTION
Merged recording (when the merged recording is also in the table)
----------------

- move below merged recording
- remove checkbox and disable/enable button


Merged recording (when the merged recording is not in the table)
----------------

- display recording title and artist credits
- remove checkbox and disable/enable button


Deleted recording
-----------------

- mark red
- remove checkbox and disable/enable button maybe I should keep disable button but I don’t know if the case happens