### PR TITLE
Replace removed getSourceEntityInstance

### DIFF
--- a/mbz-loujine-common.js
+++ b/mbz-loujine-common.js
@@ -909,7 +909,7 @@ class RelationshipEditor {
     }
 
     // sort recordings by order in tracklist to avoid having the dialog jump everywhere
-    const recOrder = MB.getSourceEntityInstance().mediums.flatMap(
+    const recOrder = MB.relationshipEditor.state.entity.mediums.flatMap(
       // tracks on mediums 1-10 loaded by default
       m => m.tracks
     ).concat(


### PR DESCRIPTION
MB beta removed `MB.getSourceEntityInstance` and it broke at least Guess Works, but it can be replaced with `MB.relationshipEditor.state.entity` (tested and it works fine). Suggested by @mwiencek.