### PR TITLE
Don't crash on 10+ medium releases

### DIFF
--- a/mbz-loujine-common.js
+++ b/mbz-loujine-common.js
@@ -911,7 +911,7 @@ class RelationshipEditor {
     // sort recordings by order in tracklist to avoid having the dialog jump everywhere
     const recOrder = MB.getSourceEntityInstance().mediums.flatMap(
       // tracks on mediums 1-10 loaded by default
-      m => m.tracks
+      m => m.tracks ?? []
     ).concat(
       // tracks on unfolded mediums
       Array.from(MB.relationshipEditor.state.loadedTracks.keys()).sort().flatMap(


### PR DESCRIPTION
This avoids a crash "Uncaught TypeError: Cannot read properties of undefined (reading 'recording')" when trying to guess works on releases with more than 10 discs (the one I was testing on was https://musicbrainz.org/release/58e628c0-44b9-458a-9685-98a78ef3fd45)

Thanks to @mwiencek again.